### PR TITLE
Fix build on Windows with recent Visual Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,4 @@ Low level RUST APIs for cyclone
 * ```prefix_symbols```: Prefix the symbols in the Cyclone DDS and Cyclocut libraries with the version of the cyclors crate. This allows for different versions of the crate to be loaded together statically. On macOS and Windows platforms ```llvm-nm``` and ```llvm-objcopy``` are required.
 
 **Note:** The ```iceoryx``` and ```prefix_symbols``` features are optional and cannot be enabled at the same time.
+ 


### PR DESCRIPTION
In `zenoh-plugin-dds` project the CI started to fail on [Feb. 7th 2025](https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds/actions/runs/13562294850/job/37907691768) with such log:

```log
  C:\Users\runneradmin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\cyclors-0.2.5\iceoryx\iceoryx_hoofs\platform\win\source\time.cpp(42,62): error C2039: 'system_clock': is not a member of 'std::chrono' [D:\a\zenoh-plugin-ros2dds\zenoh-plugin-ros2dds\target\debug\build\cyclors-919c8cd9ceb8a9b7\out\iceoryx-build\build\hoofs\platform\iceoryx_platform.vcxproj]
        C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.43.34808\include\__msvc_chrono.hpp(286,11):
        see declaration of 'std::chrono'
```

The only change with previous succesfull build was the Windows runner switching from [20250209.1.0](https://github.com/actions/runner-images/blob/win22/20250209.1/images/windows/Windows2022-Readme.md) to [20250224.5.0](https://github.com/actions/runner-images/blob/win22/20250224.5/images/windows/Windows2022-Readme.md). 