### PR TITLE
Fix build on Windows with recent MSVC

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/eclipse-cyclonedds/cyclonedds.git
 [submodule "iceoryx"]
 	path = iceoryx
-	url = https://github.com/eclipse-iceoryx/iceoryx.git
+	url = https://github.com/ZettaScaleLabs/iceoryx.git


### PR DESCRIPTION
Builds on Github Windows runners [started to fail](https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds/actions/runs/13824033303/job/38675538368) when their version changed from [20250209.1.0](https://github.com/actions/runner-images/blob/win22/20250209.1/images/windows/Windows2022-Readme.md) to [20250224.5.0](https://github.com/actions/runner-images/blob/win22/20250224.5/images/windows/Windows2022-Readme.md). The error log is:
```log
  C:\Users\runneradmin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\cyclors-0.2.5\iceoryx\iceoryx_hoofs\platform\win\source\time.cpp(42,62): error C2039: 'system_clock': is not a member of 'std::chrono' [D:\a\zenoh-plugin-ros2dds\zenoh-plugin-ros2dds\target\debug\build\cyclors-919c8cd9ceb8a9b7\out\iceoryx-build\build\hoofs\platform\iceoryx_platform.vcxproj]
        C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.43.34808\include\__msvc_chrono.hpp(286,11):
        see declaration of 'std::chrono'
```

This error was solved in `iceoryx` with https://github.com/eclipse-iceoryx/iceoryx/pull/2378.
It has been backported to `iceoryx` 2.0.3 [in this fork](https://github.com/ZettaScaleLabs/iceoryx/tree/2.0.3_for_cyclors)
This PR makes `cyclors` to use this fork.
