### PR TITLE
Update Cyclone DDS to the latest version of master (83783976f0f131269d4065463fb01716787f4256)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cyclors"
-version = "0.3.6"
+version = "0.3.7"
 authors = ["kydos <angelo@icorsaro.net>"]
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
This includes a fix to support compilation on musl platforms.

Closes #43.